### PR TITLE
Added an auth handler and requirement

### DIFF
--- a/WhyNotEarth.Meredith.App/Auth/Handlers/DataEntryHandler.cs
+++ b/WhyNotEarth.Meredith.App/Auth/Handlers/DataEntryHandler.cs
@@ -1,0 +1,26 @@
+﻿namespace WhyNotEarth.Meredith.App.Auth.Handlers
+{
+    using Microsoft.AspNetCore.Authorization;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using WhyNotEarth.Meredith.App.Auth.Requirements;
+
+    public class DataEntryHandler : AuthorizationHandler<RoleRequirement>
+    {
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, RoleRequirement requirement)
+        {
+            if (context.User.HasClaim(c => c.Type == "nameidentifier" && c.Value == "1"))
+            {
+                context.Succeed(requirement);
+            }
+            else
+            {
+                context.Fail();
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/WhyNotEarth.Meredith.App/Auth/Requirements/RoleRequirement.cs
+++ b/WhyNotEarth.Meredith.App/Auth/Requirements/RoleRequirement.cs
@@ -1,0 +1,14 @@
+﻿namespace WhyNotEarth.Meredith.App.Auth.Requirements
+{
+    using Microsoft.AspNetCore.Authorization;
+
+    public class RoleRequirement : IAuthorizationRequirement
+    {
+        public string Role { get; set; }
+
+        public RoleRequirement(string role)
+        {
+            Role = role;
+        }
+    }
+}

--- a/WhyNotEarth.Meredith.App/Controllers/Api/v0/AuthenticationController.cs
+++ b/WhyNotEarth.Meredith.App/Controllers/Api/v0/AuthenticationController.cs
@@ -172,7 +172,7 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0
         }
 
         [Route("ping")]
-        [Authorize]
+        [Authorize(Policy = "DataEntry")]
         [HttpGet]
         public async Task<IActionResult> Ping()
         {


### PR DESCRIPTION
Issue #45 
-------------------

I added a fake handler which will have to be renamed. I also added a single requirement that would hold role data...

So ignore the commenting out of rollbar in the StartUp.cs. The important part is the addition of the policy (to show what I currently have). 

The actual logic code of the handler does not check role because I'm not sure if we want to check role. For now its just some test thinger. Like I wrote in the discord though, we cannot throw status code 403 from the handler... Well we can but like some of the SO comments state, it shouldn't be done. 

I'll leave this pull request here to easily show you what I have as I write it. I'm not sure if there's a better way to do that