### PR TITLE
Switch to ControllerBase

### DIFF
--- a/WhyNotEarth.Meredith.App/Controllers/Api/v0/AuthenticationController.cs
+++ b/WhyNotEarth.Meredith.App/Controllers/Api/v0/AuthenticationController.cs
@@ -22,7 +22,7 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0
 
     [ApiVersion("0")]
     [Route("/api/v0/authentication")]
-    public class AuthenticationController : Controller
+    public class AuthenticationController : ControllerBase
     {
         private SignInManager<User> SignInManager { get; }
         private UserManager<User> UserManager { get; }
@@ -41,13 +41,8 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
-        public async Task<IActionResult> Login([FromBody] LoginModel model)
+        public async Task<IActionResult> Login(LoginModel model)
         {
-            if (model == null)
-            {
-                return BadRequest();
-            }
-
             var result = await SignInManager.PasswordSignInAsync(model.Email, model.Password, true, false);
             if (!result.Succeeded)
             {
@@ -173,13 +168,8 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0
         [Route("register")]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
-        public async Task<IActionResult> Register([FromBody] RegisterModel model)
+        public async Task<IActionResult> Register(RegisterModel model)
         {
-            if (model == null)
-            {
-                return BadRequest();
-            }
-
             var newUser = new User
             {
                 UserName = model.Email,

--- a/WhyNotEarth.Meredith.App/Controllers/Api/v0/CardController.cs
+++ b/WhyNotEarth.Meredith.App/Controllers/Api/v0/CardController.cs
@@ -10,7 +10,7 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0
 
     [ApiVersion("0")]
     [Route("/api/v0/cards")]
-    public class CardController : Controller
+    public class CardController : ControllerBase
     {
         protected MeredithDbContext MeredithDbContext { get; }
 

--- a/WhyNotEarth.Meredith.App/Controllers/Api/v0/CategoryController.cs
+++ b/WhyNotEarth.Meredith.App/Controllers/Api/v0/CategoryController.cs
@@ -8,7 +8,7 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0
 
     [ApiVersion("0")]
     [Route("/api/v0/categories")]
-    public class CategoryController : Controller
+    public class CategoryController : ControllerBase
     {
         private MeredithDbContext MeredithDbContext { get; }
 

--- a/WhyNotEarth.Meredith.App/Controllers/Api/v0/CompanyController.cs
+++ b/WhyNotEarth.Meredith.App/Controllers/Api/v0/CompanyController.cs
@@ -7,13 +7,12 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0
     using Microsoft.Extensions.Options;
     using WhyNotEarth.Meredith.App.Models.Api.v0.Company;
     using WhyNotEarth.Meredith.Data.Entity;
-    using WhyNotEarth.Meredith.Exceptions;
     using WhyNotEarth.Meredith.Public;
     using WhyNotEarth.Meredith.Stripe.Data;
 
     [ApiVersion("0")]
     [Route("/api/v0/companies")]
-    public class CompanyController : Controller
+    public class CompanyController : ControllerBase
     {
         public CompanyController(
             MeredithDbContext meredithDbContext,
@@ -35,11 +34,6 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0
         [HttpPost]
         public async Task<IActionResult> Create(CompanyModel company)
         {
-            if (!ModelState.IsValid)
-            {
-                return BadRequest();
-            }
-
             var newCompany = await CompanyService.CreateCompanyAsync(company.Name, company.Slug);
             return Ok(new { CompanyId = newCompany.Id });
         }

--- a/WhyNotEarth.Meredith.App/Controllers/Api/v0/HotelController.cs
+++ b/WhyNotEarth.Meredith.App/Controllers/Api/v0/HotelController.cs
@@ -5,7 +5,7 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0
 
     [ApiVersion("0")]
     [Route("/api/v0/hotels")]
-    public class HotelController : Controller
+    public class HotelController : ControllerBase
     {
         private MeredithDbContext MeredithDbContext { get; }
 

--- a/WhyNotEarth.Meredith.App/Controllers/Api/v0/PageController.cs
+++ b/WhyNotEarth.Meredith.App/Controllers/Api/v0/PageController.cs
@@ -14,7 +14,7 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0
 
     [ApiVersion("0")]
     [Route("/api/v0/pages")]
-    public class PageController : Controller
+    public class PageController : ControllerBase
     {
         private MeredithDbContext MeredithDbContext { get; }
 

--- a/WhyNotEarth.Meredith.App/Controllers/Api/v0/PlanetCollageController.cs
+++ b/WhyNotEarth.Meredith.App/Controllers/Api/v0/PlanetCollageController.cs
@@ -11,7 +11,7 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0
 
     [ApiVersion("0")]
     [Route("/api/v0/planetcollage")]
-    public class PlanetCollageController : Controller
+    public class PlanetCollageController : ControllerBase
     {
         protected CloudinaryOptions CloudinaryOptions { get; }
 
@@ -67,7 +67,7 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0
 
         [HttpPost]
         [Route("full")]
-        public IActionResult FullResolution([FromBody] FullResolutionModel model)
+        public IActionResult FullResolution(FullResolutionModel model)
         {
             return Ok(new
             {

--- a/WhyNotEarth.Meredith.App/Controllers/Api/v0/PriceController.cs
+++ b/WhyNotEarth.Meredith.App/Controllers/Api/v0/PriceController.cs
@@ -3,32 +3,23 @@
     using Microsoft.AspNetCore.Mvc;
     using System.Threading.Tasks;
     using WhyNotEarth.Meredith.App.Models.Api.v0.Price;
-    using WhyNotEarth.Meredith.Data.Entity;
-    using WhyNotEarth.Meredith.Exceptions;
     using WhyNotEarth.Meredith.Hotel;
 
     [ApiVersion("0")]
     [Route("/api/v0/prices")]
-    public class PriceController : Controller
+    public class PriceController : ControllerBase
     {
-        private MeredithDbContext MeredithDbContext { get; }
         private PriceService PriceService { get; }
 
-        public PriceController(MeredithDbContext meredithDbContext, PriceService priceService)
+        public PriceController(PriceService priceService)
         {
             PriceService = priceService;
-            MeredithDbContext = meredithDbContext;
         }
 
         [HttpPost]
         [Route("")]
         public async Task<IActionResult> Create(PriceModel price)
         {
-            if (!ModelState.IsValid)
-            {
-                return BadRequest();
-            }
-
             var newPrice = await PriceService.CreatePriceAsync(price.Amount, price.Date, price.RoomTypeId);
             return Ok(new { PriceId = newPrice.Id });
         }

--- a/WhyNotEarth.Meredith.App/Controllers/Api/v0/ReservationController.cs
+++ b/WhyNotEarth.Meredith.App/Controllers/Api/v0/ReservationController.cs
@@ -15,7 +15,7 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0
 
     [ApiVersion("0")]
     [Route("/api/v0/reservations")]
-    public class ReservationController : Controller
+    public class ReservationController : ControllerBase
     {
         private MeredithDbContext MeredithDbContext { get; }
 
@@ -75,13 +75,8 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public async Task<IActionResult> PayReservation(int reservationId, [FromBody] PayModel model)
+        public async Task<IActionResult> PayReservation(int reservationId, PayModel model)
         {
-            if (!ModelState.IsValid)
-            {
-                return BadRequest();
-            }
-
             var reservation = await MeredithDbContext.Reservations.FirstOrDefaultAsync(item => item.Id == reservationId);
 
             if (reservation is null)
@@ -97,13 +92,8 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0
         [Authorize]
         [HttpPost]
         [Route("roomtype/{roomTypeId}/reserve")]
-        public async Task<IActionResult> ReserveByRoomType(int roomTypeId, [FromBody] ReservationModel model)
+        public async Task<IActionResult> ReserveByRoomType(int roomTypeId, ReservationModel model)
         {
-            if (!ModelState.IsValid)
-            {
-                return BadRequest();
-            }
-
             var reservation = await ReservationService.CreateReservation(
                 roomTypeId, model.Start, model.End, model.Name, model.Email, model.Message, model.PhoneCountry, model.Phone,
                 model.NumberOfGuests);

--- a/WhyNotEarth.Meredith.App/Controllers/Api/v0/RoomTypeContoller.cs
+++ b/WhyNotEarth.Meredith.App/Controllers/Api/v0/RoomTypeContoller.cs
@@ -12,7 +12,7 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0
 {
     [ApiVersion("0")]
     [Route("/api/v0/roomtypes")]
-    public class RoomTypeController : Controller
+    public class RoomTypeController : ControllerBase
     {
         private MeredithDbContext MeredithDbContext { get; }
 

--- a/WhyNotEarth.Meredith.App/Controllers/StripeOAuthController.cs
+++ b/WhyNotEarth.Meredith.App/Controllers/StripeOAuthController.cs
@@ -11,7 +11,7 @@ namespace WhyNotEarth.Meredith.App.Controllers
 
     [Route("/stripe/oauth")]
     [DisableCors]
-    public class StripeOAuthController : Controller
+    public class StripeOAuthController : ControllerBase
     {
         protected StripeOAuthService StripeOAuthServices { get; }
 
@@ -35,7 +35,8 @@ namespace WhyNotEarth.Meredith.App.Controllers
             }
 
             await StripeOAuthServices.Register(Guid.Parse(model.State), model.Code);
-            return View();
+
+            return Ok("Your Stripe account has been connected with Meredith, you can now close your browser.");
         }
     }
 }

--- a/WhyNotEarth.Meredith.App/Startup.cs
+++ b/WhyNotEarth.Meredith.App/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,6 +25,7 @@ using WhyNotEarth.Meredith.DependencyInjection;
 using WhyNotEarth.Meredith.Email;
 using WhyNotEarth.Meredith.Stripe.Data;
 
+[assembly: ApiController]
 namespace WhyNotEarth.Meredith.App
 {
     public class Startup

--- a/WhyNotEarth.Meredith.App/Views/StripeOAuth/Authorize.cshtml
+++ b/WhyNotEarth.Meredith.App/Views/StripeOAuth/Authorize.cshtml
@@ -1,1 +1,0 @@
-Your Stripe account has been connected with Meredith, you can now close your browser.


### PR DESCRIPTION
Switch to ControllerBase as it is the intended base class for API controllers and add APIController attribute to the assembly
With ApiController attribute we don't need to add the FromBody to complex types and also validity of model states will be checked automatically
