### PR TITLE
Twilio Whatsapp Integration For Order Reservation. Fixes #169

### DIFF
--- a/WhyNotEarth.Meredith.App/Configuration/Options.cs
+++ b/WhyNotEarth.Meredith.App/Configuration/Options.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using RollbarDotNet.Configuration;
 using WhyNotEarth.Meredith.Cloudinary;
 using WhyNotEarth.Meredith.GoogleCloud;
+using WhyNotEarth.Meredith.Sms;
 using WhyNotEarth.Meredith.Stripe.Data;
 
 namespace WhyNotEarth.Meredith.App.Configuration
@@ -16,7 +17,8 @@ namespace WhyNotEarth.Meredith.App.Configuration
                 .Configure<RollbarOptions>(o => configuration.GetSection("Rollbar").Bind(o))
                 .Configure<StripeOptions>(o => configuration.GetSection("Stripe").Bind(o))
                 .Configure<JwtOptions>(o => configuration.GetSection("Jwt").Bind(o))
-                .Configure<GoogleCloudOptions>(o => configuration.GetSection("GoogleCloud").Bind(o));
+                .Configure<GoogleCloudOptions>(o => configuration.GetSection("GoogleCloud").Bind(o))
+                .Configure<TwilioOptions>(o => configuration.GetSection("Twilio").Bind(o));
         }
     }
 }

--- a/WhyNotEarth.Meredith.App/Controllers/Api/v0/Tenant/TenantReservationController.cs
+++ b/WhyNotEarth.Meredith.App/Controllers/Api/v0/Tenant/TenantReservationController.cs
@@ -53,7 +53,7 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0.Tenant
 
             _reservationService.Reserve(tenant.Id, model.Orders.Select(i => i.ToString()).ToList(), model.SubTotal,
                 model.DeliveryFee, model.Amount, model.Tax, model.DeliveryDateTime, model.UserTimeZoneOffset,
-                model.PaymentMethod, model.Message, userId);
+                model.PaymentMethod, model.Message, userId, model.WhatsappNotification);
 
             return Ok();
         }

--- a/WhyNotEarth.Meredith.App/Models/Api/v0/Salon/TenantReservationModel.cs
+++ b/WhyNotEarth.Meredith.App/Models/Api/v0/Salon/TenantReservationModel.cs
@@ -24,6 +24,8 @@ namespace WhyNotEarth.Meredith.App.Models.Api.v0.Salon
         public string PaymentMethod { get; set; } = null!;
 
         public string? Message { get; set; }
+
+        public bool? WhatsappNotification { get; set; }
     }
 
     public class Order

--- a/WhyNotEarth.Meredith.App/appsettings.json
+++ b/WhyNotEarth.Meredith.App/appsettings.json
@@ -1,49 +1,54 @@
 {
-    "ConnectionStrings": {
-        "Default": "User ID=#{database.user};Password=#{database.password};Host=#{database.host};Port=5432;Database=#{database.name};"
+  "ConnectionStrings": {
+    "Default": "User ID=#{database.user};Password=#{database.password};Host=#{database.host};Port=5432;Database=#{database.name};"
+  },
+  "Authentication": {
+    "Google": {
+      "ClientId": "#{auth.google.clientid}",
+      "ClientSecret": "#{auth.google.clientsecret}"
     },
-    "Authentication": {
-        "Google": {
-            "ClientId": "#{auth.google.clientid}",
-            "ClientSecret": "#{auth.google.clientsecret}"
-        },
-        "Facebook": {
-            "ClientId": "#{auth.facebook.clientid}",
-            "ClientSecret": "#{auth.facebook.clientsecret}"
-        }
-    },
-    "Cloudinary": {
-        "ApiKey": "#{cloudinary.apiKey}",
-        "ApiSecret": "#{cloudinary.apiSecret}",
-        "CloudName": "#{cloudinary.cloudName}"
-    },
-    "Stripe": {
-        "ClientId": "#{stripe.clientid}",
-        "ClientSecret": "#{stripe.clientsecret}",
-        "PublishableKey": "#{stripe.publishablekey}",
-        "RedirectUri": "#{stripe.redirecturi}",
-        "EndpointSecret": "#{stripe.endpointsecret}",
-    },
-    "Rollbar": {
-        "AccessToken": "#{rollbar.accesstoken}",
-        "Environment": "#{rollbar.environment}"
-    },
-    "Jwt": {
-        "Key": "#{jwt.key}",
-        "Issuer": "#{jwt.issuer}",
-        "ExpireDays": 30
-    },
-    "GoogleCloud": {
-        "ProjectId": "#{googlecloud.projectid}",
-        "ClientEmail": "#{googlecloud.clientemail}",
-        "PrivateKey": "#{googlecloud.privatekey}",
-        "StorageBucket": "#{googlecloud.storagebucket}"
-    },
-    "Logging": {
-        "IncludeScopes": true,
-        "LogLevel": {
-            "Default": "Error",
-            "Hangfire": "Error"
-        }
+    "Facebook": {
+      "ClientId": "#{auth.facebook.clientid}",
+      "ClientSecret": "#{auth.facebook.clientsecret}"
     }
+  },
+  "Cloudinary": {
+    "ApiKey": "#{cloudinary.apiKey}",
+    "ApiSecret": "#{cloudinary.apiSecret}",
+    "CloudName": "#{cloudinary.cloudName}"
+  },
+  "Stripe": {
+    "ClientId": "#{stripe.clientid}",
+    "ClientSecret": "#{stripe.clientsecret}",
+    "PublishableKey": "#{stripe.publishablekey}",
+    "RedirectUri": "#{stripe.redirecturi}",
+    "EndpointSecret": "#{stripe.endpointsecret}",
+  },
+  "Rollbar": {
+    "AccessToken": "#{rollbar.accesstoken}",
+    "Environment": "#{rollbar.environment}"
+  },
+  "Jwt": {
+    "Key": "#{jwt.key}",
+    "Issuer": "#{jwt.issuer}",
+    "ExpireDays": 30
+  },
+  "Twilio": {
+    "AccountSID": "#{twilio.accountsid}",
+    "AuthToken": "#{twilio.authtoken}",
+    "PhoneNumber": "#{twilio.phonenumber}"
+  },
+  "GoogleCloud": {
+    "ProjectId": "#{googlecloud.projectid}",
+    "ClientEmail": "#{googlecloud.clientemail}",
+    "PrivateKey": "#{googlecloud.privatekey}",
+    "StorageBucket": "#{googlecloud.storagebucket}"
+  },
+  "Logging": {
+    "IncludeScopes": true,
+    "LogLevel": {
+      "Default": "Error",
+      "Hangfire": "Error"
+    }
+  }
 }

--- a/WhyNotEarth.Meredith.Data.Entity/Migrations/20200513115036_AddContactInfoToUser.Designer.cs
+++ b/WhyNotEarth.Meredith.Data.Entity/Migrations/20200513115036_AddContactInfoToUser.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WhyNotEarth.Meredith.Data.Entity;
@@ -9,9 +10,10 @@ using WhyNotEarth.Meredith.Data.Entity;
 namespace WhyNotEarth.Meredith.Data.Entity.Migrations
 {
     [DbContext(typeof(MeredithDbContext))]
-    partial class MeredithDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200513115036_AddContactInfoToUser")]
+    partial class AddContactInfoToUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -808,6 +810,9 @@ namespace WhyNotEarth.Meredith.Data.Entity.Migrations
                     b.Property<int?>("ImageId")
                         .HasColumnType("integer");
 
+                    b.Property<int?>("JumpStartId")
+                        .HasColumnType("integer");
+
                     b.Property<int?>("Order")
                         .HasColumnType("integer");
 
@@ -819,6 +824,8 @@ namespace WhyNotEarth.Meredith.Data.Entity.Migrations
                     b.HasIndex("CategoryId");
 
                     b.HasIndex("ImageId");
+
+                    b.HasIndex("JumpStartId");
 
                     b.ToTable("Articles","ModuleVolkswagen");
                 });
@@ -1122,26 +1129,6 @@ namespace WhyNotEarth.Meredith.Data.Entity.Migrations
                     b.HasIndex("CompanyId");
 
                     b.ToTable("SendGridAccounts");
-                });
-
-            modelBuilder.Entity("WhyNotEarth.Meredith.Data.Entity.Models.Setting", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer")
-                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn);
-
-                    b.Property<int>("CompanyId")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("Value")
-                        .HasColumnType("text");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CompanyId");
-
-                    b.ToTable("Settings");
                 });
 
             modelBuilder.Entity("WhyNotEarth.Meredith.Data.Entity.Models.StripeAccount", b =>
@@ -1745,6 +1732,10 @@ namespace WhyNotEarth.Meredith.Data.Entity.Migrations
                     b.HasOne("WhyNotEarth.Meredith.Data.Entity.Models.Modules.Volkswagen.ArticleImage", "Image")
                         .WithMany()
                         .HasForeignKey("ImageId");
+
+                    b.HasOne("WhyNotEarth.Meredith.Data.Entity.Models.Modules.Volkswagen.JumpStart", "JumpStart")
+                        .WithMany("Articles")
+                        .HasForeignKey("JumpStartId");
                 });
 
             modelBuilder.Entity("WhyNotEarth.Meredith.Data.Entity.Models.Modules.Volkswagen.EmailRecipient", b =>
@@ -1806,15 +1797,6 @@ namespace WhyNotEarth.Meredith.Data.Entity.Migrations
                 });
 
             modelBuilder.Entity("WhyNotEarth.Meredith.Data.Entity.Models.SendGridAccount", b =>
-                {
-                    b.HasOne("WhyNotEarth.Meredith.Data.Entity.Models.Company", "Company")
-                        .WithMany()
-                        .HasForeignKey("CompanyId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-                });
-
-            modelBuilder.Entity("WhyNotEarth.Meredith.Data.Entity.Models.Setting", b =>
                 {
                     b.HasOne("WhyNotEarth.Meredith.Data.Entity.Models.Company", "Company")
                         .WithMany()

--- a/WhyNotEarth.Meredith.Data.Entity/Migrations/20200513115036_AddContactInfoToUser.cs
+++ b/WhyNotEarth.Meredith.Data.Entity/Migrations/20200513115036_AddContactInfoToUser.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace WhyNotEarth.Meredith.Data.Entity.Migrations
+{
+    public partial class AddContactInfoToUser : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "FacebookUrl",
+                table: "Users",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InstagramUrl",
+                table: "Users",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "WhatsappNotification",
+                table: "Users",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FacebookUrl",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "InstagramUrl",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "WhatsappNotification",
+                table: "Users");
+        }
+    }
+}

--- a/WhyNotEarth.Meredith.Data.Entity/Models/Tenant.cs
+++ b/WhyNotEarth.Meredith.Data.Entity/Models/Tenant.cs
@@ -27,7 +27,7 @@ namespace WhyNotEarth.Meredith.Data.Entity.Models
 
         public TimeSpan DeliveryTime { get; set; }
 
-        public decimal DeliveryFee { get; set; }
+        public decimal DeliveryFee { get; set; }        
 
         public ICollection<Page> Pages { get; set; }
 

--- a/WhyNotEarth.Meredith.Data.Entity/Models/User.cs
+++ b/WhyNotEarth.Meredith.Data.Entity/Models/User.cs
@@ -12,6 +12,12 @@ namespace WhyNotEarth.Meredith.Data.Entity.Models
 
         public string GoogleLocation { get; set; }
 
+        public bool WhatsappNotification { get; set; }
+
+        public string FacebookUrl { get; set; }
+
+        public string InstagramUrl { get; set; }
+
         public void Configure(EntityTypeBuilder<User> builder)
         {
             builder.ToTable("Users");

--- a/WhyNotEarth.Meredith.Data.Entity/WhyNotEarth.Meredith.Data.Entity.csproj
+++ b/WhyNotEarth.Meredith.Data.Entity/WhyNotEarth.Meredith.Data.Entity.csproj
@@ -14,7 +14,4 @@
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Migrations" />
-  </ItemGroup>
 </Project>

--- a/WhyNotEarth.Meredith/DependencyInjection/ServiceProviderExtensions.cs
+++ b/WhyNotEarth.Meredith/DependencyInjection/ServiceProviderExtensions.cs
@@ -49,7 +49,8 @@ namespace WhyNotEarth.Meredith.DependencyInjection
 
             // Tenant
             serviceCollection
-                .AddScoped<Tenant.ReservationService>();
+                .AddScoped<Tenant.ReservationService>()
+                .AddScoped<Sms.TwilioService>();
 
             return serviceCollection;
         }

--- a/WhyNotEarth.Meredith/Sms/OrderTemplateWhatsapp.txt
+++ b/WhyNotEarth.Meredith/Sms/OrderTemplateWhatsapp.txt
@@ -1,0 +1,29 @@
+﻿*What's coming* 
+
+{orders} 
+
+Sub-Total:  ${subTotal}
+Tax:  ${tax}
+Delivery Fee:  ${deliveryFee}
+
+*Total*:  *${amount}*
+
+*Customer Details* 
+
+Delivery Address:  {deliveryAddress}
+Customer name:  {name}
+Phone Number:  {phone}
+Email:  {email}
+Payment Method:  {paymentMethod}
+Estimated Delivery Time:  {deliveryTime}
+
+*Special Requests* 
+{message}
+
+*Thank You!*
+Thank you for ordering! Your food is being prepared. Please be prepared to pay ${amount} upon arrival.
+
+*{tenantName}*
+{tenantGooglemaps}
+{tenantPhone}
+{tenantEmail}

--- a/WhyNotEarth.Meredith/Sms/TwilioOptions.cs
+++ b/WhyNotEarth.Meredith/Sms/TwilioOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace WhyNotEarth.Meredith.Sms
+{
+    public class TwilioOptions
+    {
+        public string AccountSID { get; set; } = null!;
+        public string AuthToken { get; set; } = null!;
+        public string PhoneNumber { get; set; } = null!;
+    }
+}

--- a/WhyNotEarth.Meredith/Sms/TwilioService.cs
+++ b/WhyNotEarth.Meredith/Sms/TwilioService.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Twilio;
+using Twilio.Rest.Api.V2010.Account;
+using Twilio.Rest.Lookups.V1;
+
+namespace WhyNotEarth.Meredith.Sms
+{
+    public class TwilioService
+    {
+        private readonly TwilioOptions _options;
+        private const string WhatsappOrderSmsTemplateName = "OrderTemplateWhatsapp.txt";
+
+        public TwilioService(IOptions<TwilioOptions> options)
+        {
+            _options = options.Value;            
+        }
+
+        public string GetWhatsappSmsTemplate()
+        {
+            var assembly = typeof(TwilioService).GetTypeInfo().Assembly;
+
+            var name = assembly.GetManifestResourceNames().FirstOrDefault(item => item.EndsWith(WhatsappOrderSmsTemplateName));
+            var stream = assembly.GetManifestResourceStream(name);
+
+            if (stream is null)
+            {
+                throw new Exception($"Missing resource.");
+            }
+
+            var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
+        }
+
+        public async Task SendWhatsapp(string body, List<string> recipients)
+        {
+            TwilioClient.Init(_options.AccountSID, _options.AuthToken);
+            foreach (var item in recipients)
+            {
+                var phoneResult = await PhoneNumberResource.FetchAsync(
+                        countryCode: "KH",
+                        pathPhoneNumber: new Twilio.Types.PhoneNumber(item)
+                    );
+
+                var result = await MessageResource.CreateAsync(
+                    body: body,
+                    from: new Twilio.Types.PhoneNumber("whatsapp:" + _options.PhoneNumber),
+                    to: new Twilio.Types.PhoneNumber("whatsapp:" + phoneResult.PhoneNumber)
+                );
+            }
+        }
+    }
+}

--- a/WhyNotEarth.Meredith/Tenant/ReservationService.cs
+++ b/WhyNotEarth.Meredith/Tenant/ReservationService.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading.Tasks;
 using Hangfire;
 using Microsoft.EntityFrameworkCore;
 using WhyNotEarth.Meredith.Data.Entity;
 using WhyNotEarth.Meredith.Email;
 using WhyNotEarth.Meredith.Identity;
+using WhyNotEarth.Meredith.Sms;
 
 namespace WhyNotEarth.Meredith.Tenant
 {
@@ -15,23 +17,34 @@ namespace WhyNotEarth.Meredith.Tenant
         private readonly MeredithDbContext _meredithDbContext;
         private readonly SendGridService _sendGridService;
         private readonly UserManager _userManager;
+        private readonly TwilioService _twilioService;
 
         public ReservationService(MeredithDbContext meredithDbContext, SendGridService sendGridService,
-            IBackgroundJobClient backgroundJobClient, UserManager userManager)
+            IBackgroundJobClient backgroundJobClient, UserManager userManager, TwilioService twilioService)
         {
             _meredithDbContext = meredithDbContext;
             _sendGridService = sendGridService;
             _backgroundJobClient = backgroundJobClient;
             _userManager = userManager;
+            _twilioService = twilioService;
         }
 
         public void Reserve(int tenantId, List<string> orders, decimal subTotal, decimal deliveryFee, decimal amount,
             decimal tax, DateTime deliveryDateTime, int userTimeZoneOffset, string paymentMethod, string? message,
-            string userId)
+            string userId, bool? whatsappNotification)
         {
-            _backgroundJobClient.Enqueue<ReservationService>(service =>
-                service.SendEmail(tenantId, orders, subTotal, deliveryFee, amount, tax, deliveryDateTime,
-                    userTimeZoneOffset, paymentMethod, message, userId));
+            if (whatsappNotification == true)
+            {
+                _backgroundJobClient.Enqueue<ReservationService>(service =>
+               service.SendWhatsappSms(tenantId, orders, subTotal, deliveryFee, amount, tax, deliveryDateTime,
+                   userTimeZoneOffset, paymentMethod, message, userId));
+            }
+            else
+            {
+                _backgroundJobClient.Enqueue<ReservationService>(service =>
+                    service.SendEmail(tenantId, orders, subTotal, deliveryFee, amount, tax, deliveryDateTime,
+                        userTimeZoneOffset, paymentMethod, message, userId));
+            }
         }
 
         public async Task SendEmail(int tenantId, List<string> orders, decimal subTotal, decimal deliveryFee,
@@ -76,6 +89,43 @@ namespace WhyNotEarth.Meredith.Tenant
             };
 
             await _sendGridService.SendEmail(tenant.Company.Id, recipients, templateData);
+        }
+        public async Task SendWhatsappSms(int tenantId, List<string> orders, decimal subTotal, decimal deliveryFee,
+            decimal amount, decimal tax, DateTime deliveryDateTime, int userTimeZoneOffset, string paymentMethod,
+            string? message, string userId)
+        {
+            var user = await _userManager.FindByIdAsync(userId);
+
+            var tenant = await _meredithDbContext.Tenants
+                .Include(item => item.User)
+                .FirstOrDefaultAsync(item => item.Id == tenantId);
+
+            var recepients = new List<string>()
+            {
+                user.PhoneNumber,
+                tenant.User.PhoneNumber
+            };
+
+            StringBuilder formatReader = new StringBuilder(_twilioService.GetWhatsappSmsTemplate());
+
+            formatReader.Replace("{orders}", string.Join("\n", orders));
+            formatReader.Replace("{subTotal}", subTotal.ToString());
+            formatReader.Replace("{tax}", tax.ToString());
+            formatReader.Replace("{deliveryFee}", deliveryFee.ToString());
+            formatReader.Replace("{amount}", amount.ToString());
+            formatReader.Replace("{deliveryAddress}", user.Address);
+            formatReader.Replace("{name}", user.Name);
+            formatReader.Replace("{phone}", user.PhoneNumber);
+            formatReader.Replace("{email}", user.Email);
+            formatReader.Replace("{paymentMethod}", paymentMethod);
+            formatReader.Replace("{deliveryTime}", deliveryDateTime.InZone(userTimeZoneOffset, "ddd, d MMM hh:mm"));
+            formatReader.Replace("{message}", !string.IsNullOrEmpty(message) ? message : "N/A");
+            formatReader.Replace("{tenantName}", tenant.Name.ToUpper());
+            formatReader.Replace("{tenantGooglemaps}", tenant.User.GoogleLocation);
+            formatReader.Replace("{tenantPhone}", tenant.User.PhoneNumber);
+            formatReader.Replace("{tenantEmail}", tenant.User.Email);
+
+            await _twilioService.SendWhatsapp(formatReader.ToString(), recepients);
         }
     }
 }

--- a/WhyNotEarth.Meredith/WhyNotEarth.Meredith.csproj
+++ b/WhyNotEarth.Meredith/WhyNotEarth.Meredith.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Sms/OrderTemplateWhatsapp.txt" />
     <EmbeddedResource Include="Volkswagen/Templates/three-column.html" />
     <EmbeddedResource Include="Volkswagen/Templates/three-column-pdf.html" />
     <EmbeddedResource Include="Volkswagen/Templates/two-column.html" />
@@ -26,6 +27,7 @@
     <PackageReference Include="PuppeteerSharp" Version="2.0.3" />
     <PackageReference Include="SendGrid" Version="9.14.1" />
     <PackageReference Include="Stripe.net" Version="36.8.0" />
+    <PackageReference Include="Twilio" Version="5.40.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\WhyNotEarth.Meredith.Data.Entity\WhyNotEarth.Meredith.Data.Entity.csproj" />


### PR DESCRIPTION
- Added new endpoint for sending whatsapp notification [From us (Foodouken) to Tenant and User] for reservations - api/v0/tenants/{tenantSlug}/reservations/whatsapp , which executes a background job

- Properties added to as per comment in [https://github.com/whynotearth/meredith-core/issues/169]
Tenant: PhoneNumber, WhatsappNumber, Whatsapp_OptIn
User: Whatsapp_OptIn

- As discussed with @paulchrisluke , whatsapp number and opt_in would be required and included in terms and conditions.

- The main thing to test is with various numbers stored in database. Twilio's FetchAsync of Lookup API handles conversion of number in required format (E.164), so manual validations and handling was not needed.