### PR TITLE
Added Fetch Tenants By User endpoint. Fixes #201

### DIFF
--- a/WhyNotEarth.Meredith.App/Controllers/Api/v0/Tenant/TenantController.cs
+++ b/WhyNotEarth.Meredith.App/Controllers/Api/v0/Tenant/TenantController.cs
@@ -46,5 +46,15 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0.Tenant
 
             return Ok(tenants.Select(item => new TenantResult(item)).ToList());
         }
+
+        [Authorize]
+        [HttpGet("mytenants")]
+        public async Task<ActionResult<List<string>>> GetAllTenantsByUser(string companySlug, string? tenantSlug)
+        {
+            var user = await _userManager.GetUserAsync(User);
+            var tenants = await _tenantService.GetAllTenantByUser(user, companySlug, tenantSlug);
+
+            return Ok(tenants);
+        }
     }
 }

--- a/WhyNotEarth.Meredith/Tenant/TenantService.cs
+++ b/WhyNotEarth.Meredith/Tenant/TenantService.cs
@@ -49,6 +49,20 @@ namespace WhyNotEarth.Meredith.Tenant
             return _dbContext.Tenants.FirstOrDefaultAsync(item => item.OwnerId == user.Id);
         }
 
+        public async Task<List<string?>> GetAllTenantByUser(User user, string companySlug, string? tenantSlug)
+        {
+            var tenants = _dbContext.Tenants
+                                       .Include(item => item.Company)
+                                       .Where(item => item.Company.Slug == companySlug.ToLower() && item.OwnerId == user.Id);
+
+            if (!string.IsNullOrEmpty(tenantSlug))
+            {
+                tenants = tenants.Where(item => item.Slug == tenantSlug.ToLower());
+            }
+
+            return await tenants.Select(t => t.Slug).ToListAsync();
+        }
+
         private async Task<Company> ValidateAsync(string companySlug, string slug)
         {
             var company =


### PR DESCRIPTION
Added new endpoint to fetch tenant slugs of a user - _api/v0/companies/{companySlug}/tenants/gettenantsbyuser_.

One To many relationship between Tenant and User was already fixed by @ctyar 

As discussed with @atharva3010 , if the request body contains a slug, it will return a bool. Else it will return all the tenant slugs of a user