### PR TITLE
Fixed tenant slug creation. Fixes #216

### DIFF
--- a/WhyNotEarth.Meredith/Public/SlugService.cs
+++ b/WhyNotEarth.Meredith/Public/SlugService.cs
@@ -1,10 +1,30 @@
-﻿namespace WhyNotEarth.Meredith.Public
+﻿using Slugify;
+using System.Threading.Tasks;
+using WhyNotEarth.Meredith.Data.Entity;
+
+namespace WhyNotEarth.Meredith.Public
 {
     public class SlugService
     {
+        private readonly MeredithDbContext _dbContext;
+
+        public SlugService(MeredithDbContext dbContext)
+        {
+            _dbContext = dbContext;
+        }        
+
         public string GetSlug(string name)
         {
             return name.ToLower();
+        }
+
+        public async Task<string> UpdateSlug(string name, Data.Entity.Models.Tenant tenant)
+        {
+            tenant.Slug = new SlugHelper().GenerateSlug(name + " " + tenant.Id);
+            _dbContext.Tenants.Update(tenant);
+            await _dbContext.SaveChangesAsync();
+
+            return tenant.Slug;            
         }
     }
 }

--- a/WhyNotEarth.Meredith/WhyNotEarth.Meredith.csproj
+++ b/WhyNotEarth.Meredith/WhyNotEarth.Meredith.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
     <PackageReference Include="PuppeteerSharp" Version="2.0.3" />
     <PackageReference Include="SendGrid" Version="9.15.1" />
+    <PackageReference Include="Slugify.Core" Version="2.3.0" />
     <PackageReference Include="Stripe.net" Version="37.4.0" />
     <PackageReference Include="Twilio" Version="5.41.1" />
   </ItemGroup>


### PR DESCRIPTION
Used Slugify.Core - https://www.nuget.org/packages/Slugify.Core/ for slug creation.
We now generate slug as 'shop-15' where 15 is the TenantId.

We now need to do slug lookup via 'Id' instead of whole slug comparison.