### PR TITLE
Added new method for Tenant shop seo schema

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,6 @@ indent_style = space
 tab_width = 4
 
 end_of_line = crlf
-insert_final_newline = false
 
 dotnet_sort_system_directives_first = true
 csharp_using_directive_placement = outside_namespace:suggestion

--- a/WhyNotEarth.Meredith.App/Controllers/Api/v0/Tenant/TenantController.cs
+++ b/WhyNotEarth.Meredith.App/Controllers/Api/v0/Tenant/TenantController.cs
@@ -18,12 +18,14 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0.Tenant
     public class TenantController : BaseController
     {
         private readonly TenantService _tenantService;
+        private readonly SeoSchemaService _seoSchemaService;
         private readonly UserManager _userManager;
 
-        public TenantController(UserManager userManager, TenantService tenantService)
+        public TenantController(UserManager userManager, TenantService tenantService, SeoSchemaService seoSchemaService)
         {
             _userManager = userManager;
             _tenantService = tenantService;
+            _seoSchemaService = seoSchemaService;
         }
 
         [Authorize]
@@ -87,7 +89,9 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0.Tenant
                 throw new RecordNotFoundException($"Tenant {tenantSlug} not found");
             }
 
-            return Ok(new TenantResult(tenant));
+            var schema = _seoSchemaService.CreateTenantShopSchema(tenant);
+
+            return Ok(new TenantResult(tenant, schema));
         }
 
         [Authorize]

--- a/WhyNotEarth.Meredith.App/Results/Api/v0/Public/ImageResult.cs
+++ b/WhyNotEarth.Meredith.App/Results/Api/v0/Public/ImageResult.cs
@@ -10,11 +10,17 @@ namespace WhyNotEarth.Meredith.App.Results.Api.v0.Public
 
         public int Order { get; }
 
+        public int? Width { get; }
+
+        public int? Height { get; }
+
         public ImageResult(Image image)
         {
             PublicId = image.CloudinaryPublicId;
             Url = image.Url;
             Order = image.Order;
+            Width = image.Width;
+            Height = image.Height;
         }
     }
 }

--- a/WhyNotEarth.Meredith.App/Results/Api/v0/Public/Tenant/TenantResult.cs
+++ b/WhyNotEarth.Meredith.App/Results/Api/v0/Public/Tenant/TenantResult.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using WhyNotEarth.Meredith.Public;
@@ -43,6 +44,8 @@ namespace WhyNotEarth.Meredith.App.Results.Api.v0.Public.Tenant
 
         public int PromotionPercent { get; }
 
+        public object? SeoSchema { get; }
+
         public TenantResult(Meredith.Public.Tenant tenant)
         {
             Slug = tenant.Slug;
@@ -62,6 +65,11 @@ namespace WhyNotEarth.Meredith.App.Results.Api.v0.Public.Tenant
             WhatsAppNumber = tenant.WhatsAppNumber;
             HasPromotion = tenant.HasPromotion;
             PromotionPercent = tenant.PromotionPercent;
+        }
+
+        public TenantResult(Meredith.Public.Tenant tenant, string schema) : this(tenant)
+        {
+            SeoSchema = schema is null ? null : JsonConvert.DeserializeObject<dynamic>(schema);
         }
     }
 

--- a/WhyNotEarth.Meredith.App/Results/Api/v0/Public/VideoResult.cs
+++ b/WhyNotEarth.Meredith.App/Results/Api/v0/Public/VideoResult.cs
@@ -8,10 +8,25 @@ namespace WhyNotEarth.Meredith.App.Results.Api.v0.Public
 
         public string Url { get; }
 
+        public int Width { get; }
+
+        public int Height { get; }
+
+        public double Duration { get; }
+
+        public string Format { get; }
+
+        public string ThumbnailUrl { get; }
+
         public VideoResult(Video video)
         {
             PublicId = video.CloudinaryPublicId;
             Url = video.Url;
+            Width = video.Width;
+            Height = video.Height;
+            Duration = video.Duration;
+            Format = video.Format;
+            ThumbnailUrl = video.ThumbnailUrl;
         }
     }
 }

--- a/WhyNotEarth.Meredith.Persistence/Migrations/20200814073320_AddPropertiesToVideo.Designer.cs
+++ b/WhyNotEarth.Meredith.Persistence/Migrations/20200814073320_AddPropertiesToVideo.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WhyNotEarth.Meredith.Persistence;
@@ -9,9 +10,10 @@ using WhyNotEarth.Meredith.Persistence;
 namespace WhyNotEarth.Meredith.Persistence.Migrations
 {
     [DbContext(typeof(MeredithDbContext))]
-    partial class MeredithDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200814073320_AddPropertiesToVideo")]
+    partial class AddPropertiesToVideo
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/WhyNotEarth.Meredith.Persistence/Migrations/20200814073320_AddPropertiesToVideo.cs
+++ b/WhyNotEarth.Meredith.Persistence/Migrations/20200814073320_AddPropertiesToVideo.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace WhyNotEarth.Meredith.Persistence.Migrations
+{
+    public partial class AddPropertiesToVideo : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "Duration",
+                schema: "public",
+                table: "Videos",
+                nullable: false,
+                defaultValue: 0.0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Format",
+                schema: "public",
+                table: "Videos",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Height",
+                schema: "public",
+                table: "Videos",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ThumbnailUrl",
+                schema: "public",
+                table: "Videos",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Width",
+                schema: "public",
+                table: "Videos",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Duration",
+                schema: "public",
+                table: "Videos");
+
+            migrationBuilder.DropColumn(
+                name: "Format",
+                schema: "public",
+                table: "Videos");
+
+            migrationBuilder.DropColumn(
+                name: "Height",
+                schema: "public",
+                table: "Videos");
+
+            migrationBuilder.DropColumn(
+                name: "ThumbnailUrl",
+                schema: "public",
+                table: "Videos");
+
+            migrationBuilder.DropColumn(
+                name: "Width",
+                schema: "public",
+                table: "Videos");
+        }
+    }
+}

--- a/WhyNotEarth.Meredith/Cloudinary/CloudinaryService.cs
+++ b/WhyNotEarth.Meredith/Cloudinary/CloudinaryService.cs
@@ -37,44 +37,6 @@ namespace WhyNotEarth.Meredith.Cloudinary
             return cloudinary.DestroyAsync(deleteParams);
         }
 
-        public async Task<Image?> GetUpdatedValueAsync(Image? oldValue, CloudinaryImageModel? model)
-        {
-            if (oldValue is null)
-            {
-                if (model != null)
-                {
-                    // Add
-                    return new Image
-                    {
-                        Url = model.Url,
-                        CloudinaryPublicId = model.PublicId
-                    };
-                }
-
-                return null;
-            }
-
-            if (model != null)
-            {
-                // Update
-
-                // Delete old image
-                await DeleteAsync(oldValue.CloudinaryPublicId!);
-
-                return new Image
-                {
-                    Id = oldValue.Id,
-                    Url = model.Url,
-                    CloudinaryPublicId = model.PublicId
-                };
-            }
-
-            // Delete
-            await DeleteAsync(oldValue.CloudinaryPublicId!);
-
-            return null;
-        }
-
         public async Task<List<T>> GetUpdatedValueAsync<T>(List<T>? oldValues, List<CloudinaryImageModel>? models)
             where T : Image, new()
         {
@@ -110,7 +72,9 @@ namespace WhyNotEarth.Meredith.Cloudinary
                     result.Add(new T
                     {
                         CloudinaryPublicId = model.PublicId,
-                        Url = model.Url
+                        Url = model.Url,
+                        Width = model.Width,
+                        Height = model.Height
                     });
                 }
             }
@@ -153,7 +117,12 @@ namespace WhyNotEarth.Meredith.Cloudinary
                     result.Add(new T
                     {
                         CloudinaryPublicId = model.PublicId,
-                        Url = model.Url
+                        Url = model.Url,
+                        Width = model.Width!.Value,
+                        Height = model.Height!.Value,
+                        Duration = model.Duration!.Value,
+                        Format = model.Format,
+                        ThumbnailUrl = model.ThumbnailUrl
                     });
                 }
             }

--- a/WhyNotEarth.Meredith/Cloudinary/ICloudinaryService.cs
+++ b/WhyNotEarth.Meredith/Cloudinary/ICloudinaryService.cs
@@ -11,8 +11,6 @@ namespace WhyNotEarth.Meredith.Cloudinary
 
         Task DeleteByUrlAsync(string imageUrl);
 
-        Task<Image?> GetUpdatedValueAsync(Image? oldValue, CloudinaryImageModel? model);
-
         Task<List<T>> GetUpdatedValueAsync<T>(List<T>? oldValues, List<CloudinaryImageModel>? models) where T : Image, new();
 
         Task<List<T>> GetUpdatedValueAsync<T>(List<T>? oldValues, List<CloudinaryVideoModel>? models) where T : Video, new();

--- a/WhyNotEarth.Meredith/Cloudinary/Models/CloudinaryImageModel.cs
+++ b/WhyNotEarth.Meredith/Cloudinary/Models/CloudinaryImageModel.cs
@@ -12,5 +12,13 @@ namespace WhyNotEarth.Meredith.Cloudinary.Models
         [NotNull]
         [Mandatory]
         public string? Url { get; set; }
+
+        [NotNull]
+        [Mandatory]
+        public int? Width { get; set; }
+
+        [NotNull]
+        [Mandatory]
+        public int? Height { get; set; }
     }
 }

--- a/WhyNotEarth.Meredith/Cloudinary/Models/CloudinaryVideoModel.cs
+++ b/WhyNotEarth.Meredith/Cloudinary/Models/CloudinaryVideoModel.cs
@@ -12,5 +12,25 @@ namespace WhyNotEarth.Meredith.Cloudinary.Models
         [NotNull]
         [Mandatory]
         public string? Url { get; set; }
+
+        [NotNull]
+        [Mandatory]
+        public int? Width { get; set; }
+
+        [NotNull]
+        [Mandatory]
+        public int? Height { get; set; }
+
+        [NotNull]
+        [Mandatory]
+        public double? Duration { get; set; }
+
+        [NotNull]
+        [Mandatory]
+        public string? Format { get; set; }
+
+        [NotNull]
+        [Mandatory]
+        public string? ThumbnailUrl { get; set; }
     }
 }

--- a/WhyNotEarth.Meredith/DependencyInjection/ServiceProviderExtensions.cs
+++ b/WhyNotEarth.Meredith/DependencyInjection/ServiceProviderExtensions.cs
@@ -55,7 +55,8 @@ namespace WhyNotEarth.Meredith.DependencyInjection
             serviceCollection
                 .AddScoped<TenantService>()
                 .AddScoped<ProductService>()
-                .AddScoped<ProductCategoryService>();
+                .AddScoped<ProductCategoryService>()
+                .AddScoped<SeoSchemaService>();
 
             // Volkswagen
             serviceCollection

--- a/WhyNotEarth.Meredith/Public/Video.cs
+++ b/WhyNotEarth.Meredith/Public/Video.cs
@@ -7,5 +7,15 @@ namespace WhyNotEarth.Meredith.Public
         public string CloudinaryPublicId { get; set; } = null!;
 
         public string Url { get; set; } = null!;
+
+        public int Width { get; set; }
+
+        public int Height { get; set; }
+
+        public double Duration { get; set; }
+
+        public string Format { get; set; } = null!;
+
+        public string ThumbnailUrl { get; set; } = null!;
     }
 }

--- a/WhyNotEarth.Meredith/Tenant/SeoSchemaService.cs
+++ b/WhyNotEarth.Meredith/Tenant/SeoSchemaService.cs
@@ -1,0 +1,71 @@
+﻿using Schema.NET;
+using System;
+using System.Collections.Generic;
+
+namespace WhyNotEarth.Meredith.Tenant
+{
+    public class SeoSchemaService
+    {
+        private const string ContactEmail = "chris@whynot.earth";
+        private const string ContactType = "customer support";
+        private const string Country = "Cambodia";
+
+        public string CreateTenantShopSchema(Public.Tenant tenant)
+        {
+            var shopSchema = new Corporation()
+            {
+                Url = BuildUri(tenant.Company.Slug, "shop/" + tenant.Slug),
+                Logo = GetValidUri(tenant.Logo?.Url),
+                Name = tenant.Name + " | " + tenant.Company.Name,
+                Email = tenant.Owner.Email,
+                Image = GetValidUri(tenant.Logo?.Url),
+                SameAs = new List<Uri>()
+                {
+                    GetValidUri(tenant.FacebookUrl),
+                    GetValidUri(tenant.Owner?.InstagramUrl)
+                },
+                Address = new PostalAddress()
+                {
+                    AddressLocality = tenant.Address?.City,
+                    AddressRegion = tenant.Address?.State,
+                    StreetAddress = tenant.Address?.Street,
+                    AddressCountry = Country,
+                    PostalCode = tenant.Address?.ZipCode,
+                    Url = GetValidUri(tenant.Owner?.GoogleLocation) //Google maps url
+                },
+                Telephone = tenant.PhoneNumber,
+                Description = tenant.Description,
+                ContactPoint = new ContactPoint()
+                {
+                    Url = BuildUri(tenant.Company.Slug, "contact"),
+                    Email = ContactEmail,
+                    ContactType = ContactType
+                },
+                AlternateName = tenant.Company.Name.ToLower()
+            };
+
+            return shopSchema.ToString();
+        }
+
+        private Uri? BuildUri(string? companySlug, string? websitePath, string? domainExtension = ".com")
+        {
+            var baseUri = new UriBuilder();
+            baseUri.Scheme = "https";
+            baseUri.Host = companySlug?.ToLower() + domainExtension;
+            baseUri.Path = websitePath?.ToLower();
+            return baseUri.Uri;
+        }
+
+        private Uri? GetValidUri(string? path)
+        {
+            if (!string.IsNullOrEmpty(path))
+            {
+                if (Uri.IsWellFormedUriString(path, UriKind.Absolute))
+                {
+                    return new Uri(path);
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/WhyNotEarth.Meredith/Tenant/TenantService.cs
+++ b/WhyNotEarth.Meredith/Tenant/TenantService.cs
@@ -133,6 +133,8 @@ namespace WhyNotEarth.Meredith.Tenant
                 .Include(item => item.Logo)
                 .Include(item => item.BusinessHours)
                 .Include(item => item.Address)
+                .Include(item => item.Owner)
+                .Include(item => item.Company)
                 .FirstOrDefaultAsync(item => item.Slug == tenantSlug);
         }
 

--- a/WhyNotEarth.Meredith/WhyNotEarth.Meredith.csproj
+++ b/WhyNotEarth.Meredith/WhyNotEarth.Meredith.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.4" />
     <PackageReference Include="PuppeteerSharp" Version="2.0.4" />
+    <PackageReference Include="Schema.NET" Version="7.1.0" />
     <PackageReference Include="SendGrid" Version="9.20.0" />
     <PackageReference Include="Slugify.Core" Version="2.3.0" />
     <PackageReference Include="Stripe.net" Version="37.30.0" />


### PR DESCRIPTION
- Added a new service class which creates tenant shop schema - for type 'Corporation' as per Schema.org
- Used Schema.NET library - https://github.com/RehanSaeed/Schema.NET for doing so
- We have a column named 'Custom' inside Page table, but I don't think its a good idea to store schema over there since any change to the entities may need to reflect the change in the seo schema stored. Hence, we create these schema on the fly.
- As of now, this schema is passed as a property with the GET request: _/api/v0/companies/{companySlug}/tenants/{tenantSlug}_
- The seo schema being returned is in json-ld format
