### PR TITLE
Added method for creating tenant shop schema

### DIFF
--- a/WhyNotEarth.Meredith.App/Controllers/Api/v0/Tenant/TenantController.cs
+++ b/WhyNotEarth.Meredith.App/Controllers/Api/v0/Tenant/TenantController.cs
@@ -18,12 +18,14 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0.Tenant
     public class TenantController : BaseController
     {
         private readonly TenantService _tenantService;
+        private readonly SeoSchemaService _seoSchemaService;
         private readonly UserManager _userManager;
 
-        public TenantController(UserManager userManager, TenantService tenantService)
+        public TenantController(UserManager userManager, TenantService tenantService, SeoSchemaService seoSchemaService)
         {
             _userManager = userManager;
             _tenantService = tenantService;
+            _seoSchemaService = seoSchemaService;
         }
 
         [Authorize]
@@ -87,7 +89,9 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0.Tenant
                 throw new RecordNotFoundException($"Tenant {tenantSlug} not found");
             }
 
-            return Ok(new TenantResult(tenant));
+            var schema = _seoSchemaService.CreateTenantShopSchema(tenant);
+
+            return Ok(new TenantResult(tenant, schema));
         }
 
         [Authorize]

--- a/WhyNotEarth.Meredith.App/Results/Api/v0/Public/Tenant/TenantResult.cs
+++ b/WhyNotEarth.Meredith.App/Results/Api/v0/Public/Tenant/TenantResult.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 using WhyNotEarth.Meredith.Public;
 using WhyNotEarth.Meredith.Shop;
 using DayOfWeek = WhyNotEarth.Meredith.Shop.DayOfWeek;
@@ -43,6 +44,8 @@ namespace WhyNotEarth.Meredith.App.Results.Api.v0.Public.Tenant
 
         public int PromotionPercent { get; }
 
+        public object? SeoSchema { get; }
+
         public TenantResult(Meredith.Public.Tenant tenant)
         {
             Slug = tenant.Slug;
@@ -62,6 +65,11 @@ namespace WhyNotEarth.Meredith.App.Results.Api.v0.Public.Tenant
             WhatsAppNumber = tenant.WhatsAppNumber;
             HasPromotion = tenant.HasPromotion;
             PromotionPercent = tenant.PromotionPercent;
+        }
+
+        public TenantResult(Meredith.Public.Tenant tenant, string schema) : this(tenant)
+        {
+            SeoSchema = schema is null ? null : JsonConvert.DeserializeObject<dynamic>(schema);
         }
     }
 

--- a/WhyNotEarth.Meredith/DependencyInjection/ServiceProviderExtensions.cs
+++ b/WhyNotEarth.Meredith/DependencyInjection/ServiceProviderExtensions.cs
@@ -55,7 +55,8 @@ namespace WhyNotEarth.Meredith.DependencyInjection
             serviceCollection
                 .AddScoped<TenantService>()
                 .AddScoped<ProductService>()
-                .AddScoped<ProductCategoryService>();
+                .AddScoped<ProductCategoryService>()
+                .AddScoped<SeoSchemaService>();
 
             // Volkswagen
             serviceCollection

--- a/WhyNotEarth.Meredith/Tenant/SeoSchemaService.cs
+++ b/WhyNotEarth.Meredith/Tenant/SeoSchemaService.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using Schema.NET;
+
+namespace WhyNotEarth.Meredith.Tenant
+{
+    public class SeoSchemaService
+    {
+        private const string ContactEmail = "chris@whynot.earth";
+        private const string ContactType = "customer support";
+        private const string Country = "Cambodia";
+
+        public string CreateTenantShopSchema(Public.Tenant tenant)
+        {
+            var shopSchema = new Corporation()
+            {
+                Url = BuildUri(tenant.Company.Slug, "shop/" + tenant.Slug),
+                Logo = GetValidUri(tenant.Logo?.Url),
+                Name = tenant.Name + " | " + tenant.Company.Name,
+                Email = tenant.Owner.Email,
+                Image = GetValidUri(tenant.Logo?.Url),
+                SameAs = new List<Uri>()
+                {
+                    GetValidUri(tenant.FacebookUrl),
+                    GetValidUri(tenant.Owner?.InstagramUrl)
+                },
+                Address = new PostalAddress()
+                {
+                    AddressLocality = tenant.Address?.City,
+                    AddressRegion = tenant.Address?.State,
+                    StreetAddress = tenant.Address?.Street,
+                    AddressCountry = Country,
+                    PostalCode = tenant.Address?.ZipCode,
+                    Url = GetValidUri(tenant.Owner?.GoogleLocation) //Google maps url
+                },
+                Telephone = tenant.PhoneNumber,
+                Description = tenant.Description,
+                ContactPoint = new ContactPoint()
+                {
+                    Url = BuildUri(tenant.Company.Slug, "contact"),
+                    Email = ContactEmail,
+                    ContactType = ContactType
+                },
+                AlternateName = tenant.Company.Name.ToLower()
+            };
+
+            return shopSchema.ToString();
+        }
+
+        private Uri? BuildUri(string? companySlug, string? websitePath, string? domainExtension = ".com")
+        {
+            var baseUri = new UriBuilder();
+            baseUri.Scheme = "https";
+            baseUri.Host = companySlug?.ToLower() + domainExtension;
+            baseUri.Path = websitePath?.ToLower();
+            return baseUri.Uri;
+        }
+
+        private Uri? GetValidUri(string? path)
+        {
+            if (!string.IsNullOrEmpty(path))
+            {
+                if (Uri.IsWellFormedUriString(path, UriKind.Absolute))
+                {
+                    return new Uri(path);
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/WhyNotEarth.Meredith/Tenant/TenantService.cs
+++ b/WhyNotEarth.Meredith/Tenant/TenantService.cs
@@ -133,6 +133,8 @@ namespace WhyNotEarth.Meredith.Tenant
                 .Include(item => item.Logo)
                 .Include(item => item.BusinessHours)
                 .Include(item => item.Address)
+                .Include(item => item.Owner)
+                .Include(item => item.Company)
                 .FirstOrDefaultAsync(item => item.Slug == tenantSlug);
         }
 

--- a/WhyNotEarth.Meredith/WhyNotEarth.Meredith.csproj
+++ b/WhyNotEarth.Meredith/WhyNotEarth.Meredith.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.4" />
     <PackageReference Include="PuppeteerSharp" Version="2.0.4" />
+    <PackageReference Include="Schema.NET" Version="7.1.0" />
     <PackageReference Include="SendGrid" Version="9.20.0" />
     <PackageReference Include="Slugify.Core" Version="2.3.0" />
     <PackageReference Include="Stripe.net" Version="37.30.0" />


### PR DESCRIPTION
- Added a new service class which creates tenant shop schema - for type 'Corporation' as per Schema.org
- Used Schema.NET library - https://github.com/RehanSaeed/Schema.NET for doing so
- As of now, this schema is passed as a property with the GET request: /api/v0/companies/{companySlug}/tenants/{tenantSlug}
- The seo schema being returned is in json-ld format