### PR TITLE
ADD - Implemented status endpoint to get the total uploaded file size of a tenant.

### DIFF
--- a/WhyNotEarth.Meredith.App/Controllers/Api/v0/Tenant/TenantController.cs
+++ b/WhyNotEarth.Meredith.App/Controllers/Api/v0/Tenant/TenantController.cs
@@ -144,5 +144,21 @@ namespace WhyNotEarth.Meredith.App.Controllers.Api.v0.Tenant
 
             return NoContent();
         }
+
+        
+        [Authorize]
+        [Returns204]
+        [Returns401]
+        [Returns403]
+        [HttpGet("status")]
+        public async Task<IActionResult> CheckTenantStatus()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            var tenant = await _tenantService.GetTenant(user);
+
+            var status = await _tenantService.GetTenantStatus(tenant.Id);
+
+            return Ok(status);
+        }
     }
 }

--- a/WhyNotEarth.Meredith.Persistence/Migrations/20200927171652_AddedFileSizeToVideoAndImage.Designer.cs
+++ b/WhyNotEarth.Meredith.Persistence/Migrations/20200927171652_AddedFileSizeToVideoAndImage.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WhyNotEarth.Meredith.Persistence;
@@ -9,9 +10,10 @@ using WhyNotEarth.Meredith.Persistence;
 namespace WhyNotEarth.Meredith.Persistence.Migrations
 {
     [DbContext(typeof(MeredithDbContext))]
-    partial class MeredithDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200927171652_AddedFileSizeToVideoAndImage")]
+    partial class AddedFileSizeToVideoAndImage
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/WhyNotEarth.Meredith.Persistence/Migrations/20200927171652_AddedFileSizeToVideoAndImage.cs
+++ b/WhyNotEarth.Meredith.Persistence/Migrations/20200927171652_AddedFileSizeToVideoAndImage.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace WhyNotEarth.Meredith.Persistence.Migrations
+{
+    public partial class AddedFileSizeToVideoAndImage : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "FileSize",
+                schema: "public",
+                table: "Videos",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "FileSize",
+                table: "Images",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FileSize",
+                schema: "public",
+                table: "Videos");
+
+            migrationBuilder.DropColumn(
+                name: "FileSize",
+                table: "Images");
+        }
+    }
+}

--- a/WhyNotEarth.Meredith/Cloudinary/CloudinaryService.cs
+++ b/WhyNotEarth.Meredith/Cloudinary/CloudinaryService.cs
@@ -69,12 +69,16 @@ namespace WhyNotEarth.Meredith.Cloudinary
                 }
                 else
                 {
+                    // First fetch image details from cloudinary to retrieve filesize.
+                    var resource = GetCloudinaryResourcePerPublicId(model.PublicId, ResourceType.Image);
+
                     result.Add(new T
                     {
                         CloudinaryPublicId = model.PublicId,
                         Url = model.Url,
                         Width = model.Width,
-                        Height = model.Height
+                        Height = model.Height,
+                        FileSize = resource?.Bytes,
                     });
                 }
             }
@@ -114,18 +118,41 @@ namespace WhyNotEarth.Meredith.Cloudinary
                 }
                 else
                 {
+                    // First fetch video details from cloudinary to retrieve filesize.
+                    var resource = GetCloudinaryResourcePerPublicId(model.PublicId, ResourceType.Video);
+
                     result.Add(new T
                     {
                         CloudinaryPublicId = model.PublicId,
                         Url = model.Url,
                         Width = model.Width!.Value,
                         Height = model.Height!.Value,
+                        FileSize = resource?.Bytes,
                         Duration = model.Duration!.Value,
                         Format = model.Format,
                         ThumbnailUrl = model.ThumbnailUrl
                     });
                 }
             }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Queries the cloudinary api to get the resource per it's public id.
+        /// </summary>
+        /// <param name="publicId"></param>
+        /// <param name="resourceType">The resource type of the resource to fetch.</param>
+        /// <returns></returns>
+        private GetResourceResult GetCloudinaryResourcePerPublicId(string publicId, ResourceType resourceType)
+        {
+            var cloudinary = new CloudinaryDotNet.Cloudinary(new Account(_options.CloudName,
+                _options.ApiKey, _options.ApiSecret));
+
+            var par = new GetResourceParams(publicId);
+            par.ResourceType = resourceType;
+            
+            var result = cloudinary.GetResource(par);
 
             return result;
         }

--- a/WhyNotEarth.Meredith/Cloudinary/Models/CloudinaryImageModel.cs
+++ b/WhyNotEarth.Meredith/Cloudinary/Models/CloudinaryImageModel.cs
@@ -20,5 +20,9 @@ namespace WhyNotEarth.Meredith.Cloudinary.Models
         [NotNull]
         [Mandatory]
         public int? Height { get; set; }
+        
+        [NotNull]
+        [Mandatory]
+        public double FileSize { get; set; }
     }
 }

--- a/WhyNotEarth.Meredith/Cloudinary/Models/CloudinaryVideoModel.cs
+++ b/WhyNotEarth.Meredith/Cloudinary/Models/CloudinaryVideoModel.cs
@@ -20,6 +20,10 @@ namespace WhyNotEarth.Meredith.Cloudinary.Models
         [NotNull]
         [Mandatory]
         public int? Height { get; set; }
+        
+        [NotNull]
+        [Mandatory]
+        public double FileSize { get; set; }
 
         [NotNull]
         [Mandatory]

--- a/WhyNotEarth.Meredith/Public/Image.cs
+++ b/WhyNotEarth.Meredith/Public/Image.cs
@@ -17,5 +17,7 @@ namespace WhyNotEarth.Meredith.Public
         public int? Width { get; set; }
 
         public int? Height { get; set; }
+        
+        public double? FileSize { get; set; }
     }
 }

--- a/WhyNotEarth.Meredith/Public/Video.cs
+++ b/WhyNotEarth.Meredith/Public/Video.cs
@@ -11,6 +11,8 @@ namespace WhyNotEarth.Meredith.Public
         public int Width { get; set; }
 
         public int Height { get; set; }
+        
+        public double? FileSize { get; set; } 
 
         public double Duration { get; set; }
 


### PR DESCRIPTION
ADD - Implemented status endpoint to get the total file size of the tenant of the current authenticated users clients. When an image or video is being uploaded the cloudinary api is being queried to get the files size.

The file size is now being stored in the FileSize attribute of the Image and Video entity.
Therefore a new migration has been created. Later when the subscription process has been implemented the status endpoint can be extended to also return the current subscription status.